### PR TITLE
Feature: use oao.json to manage some options

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,15 +18,7 @@ import all from './all';
 
 const pkg = require('../package.json');
 
-let config;
-
-try {
-  config = require(path.resolve('oao.json'));
-} catch (err) {
-  console.log(err);
-  config = {};
-}
-
+const CONFIG = require(path.resolve('package.json')).oao || {};
 const DEFAULT_SRC_DIR = 'packages/*';
 const DEFAULT_COPY_ATTRS =
   'description,keywords,author,license,homepage,bugs,repository';
@@ -36,8 +28,8 @@ program.version(pkg.version);
 
 const checkConfigOptions = (opts) =>
   Object.assign(opts, {
-    src: opts.src !== DEFAULT_SRC_DIR ? opts.src : config.src || opts.src,
-    ignoreSrc: opts.ignoreSrc || config.ignoreSrc,
+    src: opts.src !== DEFAULT_SRC_DIR ? opts.src : CONFIG.src || opts.src,
+    ignoreSrc: opts.ignoreSrc || CONFIG.ignoreSrc,
   });
 
 const createCommand = (syntax, description) =>

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,9 @@
 #!/usr/bin/env node
 
-/* eslint-disable max-len */
+/* eslint-disable max-len, global-require, import/no-dynamic-require, no-console */
 
 import 'babel-polyfill';
+import path from 'path';
 import program from 'commander';
 import './utils/initConsole';
 import status from './status';
@@ -17,12 +18,27 @@ import all from './all';
 
 const pkg = require('../package.json');
 
+let config;
+
+try {
+  config = require(path.resolve('oao.json'));
+} catch (err) {
+  console.log(err);
+  config = {};
+}
+
 const DEFAULT_SRC_DIR = 'packages/*';
 const DEFAULT_COPY_ATTRS =
   'description,keywords,author,license,homepage,bugs,repository';
 const DEFAULT_CHANGELOG = 'CHANGELOG.md';
 
 program.version(pkg.version);
+
+const checkConfigOptions = (opts) =>
+  Object.assign(opts, {
+    src: opts.src !== DEFAULT_SRC_DIR ? opts.src : config.src || opts.src,
+    ignoreSrc: opts.ignoreSrc || config.ignoreSrc,
+  });
 
 const createCommand = (syntax, description) =>
   program
@@ -43,7 +59,7 @@ const createCommand = (syntax, description) =>
     );
 
 createCommand('status', 'Show an overview of the monorepo status').action(cmd =>
-  status(cmd.opts())
+  status(checkConfigOptions(cmd.opts()))
 );
 
 createCommand(
@@ -64,12 +80,12 @@ createCommand(
     '--no-parallel',
     "don't run yarn install in parallel (use it to debug errors, since parallel logs may be hard to read)"
   )
-  .action(cmd => bootstrap(cmd.opts()));
+  .action(cmd => bootstrap(checkConfigOptions(cmd.opts())));
 
 createCommand(
   'clean',
   'Delete all node_modules directories from sub-packages'
-).action(cmd => clean(cmd.opts()));
+).action(cmd => clean(checkConfigOptions(cmd.opts())));
 
 createCommand(
   'add <sub-package> <packages...>',
@@ -87,14 +103,14 @@ createCommand(
     'install the most recent release with the same minor version'
   )
   .action((subpackage, deps, cmd) =>
-    addRemoveUpgrade(subpackage, 'add', deps, cmd.opts())
+    addRemoveUpgrade(subpackage, 'add', deps, checkConfigOptions(cmd.opts()))
   );
 
 createCommand(
   'remove <sub-package> <packages...>',
   'Remove dependencies from a sub-package'
 ).action((subpackage, deps, cmd) =>
-  addRemoveUpgrade(subpackage, 'remove', deps, cmd.opts())
+  addRemoveUpgrade(subpackage, 'remove', deps, checkConfigOptions(cmd.opts()))
 );
 
 createCommand(
@@ -103,11 +119,11 @@ createCommand(
 )
   .option('--ignore-engines', 'disregard engines check during upgrade')
   .action((subpackage, deps, cmd) =>
-    addRemoveUpgrade(subpackage, 'upgrade', deps, cmd.opts())
+    addRemoveUpgrade(subpackage, 'upgrade', deps, checkConfigOptions(cmd.opts()))
   );
 
 createCommand('outdated', 'Check for outdated dependencies').action(cmd =>
-  outdated(cmd.opts())
+  outdated(checkConfigOptions(cmd.opts()))
 );
 
 createCommand(
@@ -119,7 +135,7 @@ createCommand(
     `copy these package.json attrs to sub-packages [${DEFAULT_COPY_ATTRS}]`,
     DEFAULT_COPY_ATTRS
   )
-  .action(cmd => prepublish(cmd.opts()));
+  .action(cmd => prepublish(checkConfigOptions(cmd.opts())));
 
 createCommand('publish', 'Publish updated sub-packages')
   .option('--no-master', 'allow publishing from a non-master branch')
@@ -146,7 +162,7 @@ createCommand('publish', 'Publish updated sub-packages')
     DEFAULT_CHANGELOG
   )
   .option('--no-changelog', 'skip changelog updates')
-  .action(cmd => publish(cmd.opts()));
+  .action(cmd => publish(checkConfigOptions(cmd.opts())));
 
 createCommand(
   'reset-all-versions <version>',
@@ -154,7 +170,7 @@ createCommand(
 )
   .option('--no-confirm', 'do not ask for confirmation')
   .action((version, cmd) => {
-    resetAllVersions(version, cmd.opts());
+    resetAllVersions(version, checkConfigOptions(cmd.opts()));
   });
 
 createCommand('all <command>', 'Run a given command on all sub-packages')
@@ -168,7 +184,7 @@ createCommand('all <command>', 'Run a given command on all sub-packages')
     'do not stop even if there are errors in some packages'
   )
   .action((command, cmd) => {
-    all(command, cmd.opts());
+    all(command, checkConfigOptions(cmd.opts()));
   });
 
 process.on('unhandledRejection', err => {

--- a/src/utils/listPaths.js
+++ b/src/utils/listPaths.js
@@ -8,7 +8,7 @@ const listPaths = async (
   src: string,
   ignoreSrc?: ?string
 ): Promise<Array<string>> => {
-  const patterns = [src];
+  const patterns = Array.isArray(src) ? src : [src];
   if (ignoreSrc) patterns.push(`!${ignoreSrc}`);
   const paths = await globby(patterns);
   return paths


### PR DESCRIPTION
Hi 😀,

I made just a simple change to can be possible to define some global options using a json config file instead of write always in the cli, as suggested on #44, but using a `oao.json` instead of put in a `package.json`, like lerna does.

For now, I put just the `--src` and `--ignoreSrc` option that can be defined. Remembering that user input options defined on cli will override the global on `oao.json`

With this change it's possible to create something like these:

```json
{
  "src": ["packages/*", "helpers/*"],
  "ignoreSrc": "others"
}
```

And I change to accept an array of globs too, instead just a string!