### PR TITLE
Add run-script support (solves #54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ $ oao all "yarn run compileWatch" --parallel
 
 ### `oao run-script <script>`
 
-Executes the specified (package) script on all sub-packages. Examples:
+Executes the specified (package) script on all sub-packages. Missing scripts will be skipped. Examples:
 
 ```sh
 $ oao run-script start

--- a/README.md
+++ b/README.md
@@ -210,6 +210,17 @@ $ oao all "yarn run compileWatch" --parallel
 
 **Note: some terminals may have problems with parallel logs (based on [terminal-kit](https://github.com/cronvel/terminal-kit)). If you experience issues, use the `--no-parallel-logs` flag. If you're using the default terminal or Hyper on OS X or Windows, you should be fine.**
 
+### `oao run-script <script>`
+
+Executes the specified (package) script on all sub-packages. Examples:
+
+```sh
+$ oao run-script start
+$ oao run-script start --parallel
+
+```
+
+By default, `oao run-script` runs sequentially. Use `--parallel` to run the scripts in parallel.
 
 ## Credits :clap:
 

--- a/src/__tests__/__snapshots__/runScript.test.js.snap
+++ b/src/__tests__/__snapshots__/runScript.test.js.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ALL command executes the specified script on all sub-packages 1`] = `
+Array [
+  Array [
+    "yarn run start",
+    Object {
+      "bareLogs": undefined,
+      "cwd": "test/fixtures/packages/oao-b",
+    },
+  ],
+  Array [
+    "yarn run start",
+    Object {
+      "bareLogs": undefined,
+      "cwd": "test/fixtures/packages/oao-c",
+    },
+  ],
+]
+`;

--- a/src/__tests__/__snapshots__/runScript.test.js.snap
+++ b/src/__tests__/__snapshots__/runScript.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ALL command executes the specified script on all sub-packages 1`] = `
+exports[`RUN-SCRIPT command executes the specified script on all sub-packages 1`] = `
 Array [
   Array [
     "yarn run start",

--- a/src/__tests__/runScript.test.js
+++ b/src/__tests__/runScript.test.js
@@ -5,7 +5,7 @@ import runScript from '../runScript';
 
 jest.mock('../utils/shell');
 
-describe('ALL command', () => {
+describe('RUN-SCRIPT command', () => {
   it('executes the specified script on all sub-packages', async () => {
     const helpers = require('../utils/shell');
     await runScript('start', { src: 'test/fixtures/packages/*' });

--- a/src/__tests__/runScript.test.js
+++ b/src/__tests__/runScript.test.js
@@ -1,0 +1,14 @@
+/* eslint-env jest */
+/* eslint-disable global-require */
+
+import runScript from '../runScript';
+
+jest.mock('../utils/shell');
+
+describe('ALL command', () => {
+  it('executes the specified script on all sub-packages', async () => {
+    const helpers = require('../utils/shell');
+    await runScript('start', { src: 'test/fixtures/packages/*' });
+    expect(helpers.exec.mock.calls).toMatchSnapshot();
+  });
+});

--- a/src/index.js
+++ b/src/index.js
@@ -16,6 +16,7 @@ import prepublish from './prepublish';
 import publish from './publish';
 import resetAllVersions from './resetAllVersions';
 import all from './all';
+import runScript from './runScript';
 
 process.env.YARN_SILENT = 0;
 
@@ -206,6 +207,20 @@ createCommand('all <command>', 'Run a given command on all sub-packages')
   )
   .action((command, cmd) => {
     all(command, processOptions(cmd.opts()));
+  });
+
+createCommand('run-script <command>', 'Run a given script on all sub-packages')
+  .option('--parallel', 'run script in parallel on all sub-packages')
+  .option(
+    '--no-parallel-logs',
+    'use chronological logging, even in parallel mode'
+  )
+  .option(
+    '--ignore-errors',
+    'do not stop even if there are errors in some packages'
+  )
+  .action((command, cmd) => {
+    runScript(command, processOptions(cmd.opts()));
   });
 
 process.on('unhandledRejection', err => {

--- a/src/runScript.js
+++ b/src/runScript.js
@@ -1,0 +1,49 @@
+// @flow
+
+import { removeAllListeners, addListener } from 'storyboard';
+import parallelConsoleListener from 'storyboard-listener-console-parallel';
+
+import { readAllSpecs } from './utils/readSpecs';
+import { exec } from './utils/shell';
+
+type Options = {
+  src: string,
+  ignoreSrc?: string,
+  parallel?: boolean,
+  parallelLogs?: boolean,
+  ignoreErrors?: boolean
+};
+
+const run = async (
+  script: string,
+  { src, ignoreSrc, parallel, parallelLogs, ignoreErrors }: Options
+) => {
+  if (parallel && parallelLogs) {
+    removeAllListeners();
+    addListener(parallelConsoleListener);
+  }
+  const allSpecs = await readAllSpecs(src, ignoreSrc, false);
+  const allPromises = [];
+  const pkgNames = Object.keys(allSpecs);
+  for (let i = 0; i < pkgNames.length; i++) {
+    const pkgName = pkgNames[i];
+    const { pkgPath, specs: prevSpecs } = allSpecs[pkgName];
+    if (prevSpecs.scripts && prevSpecs.scripts[script]) {
+      let promise = exec(`yarn run ${script}`, { cwd: pkgPath, bareLogs: parallelLogs });
+      if (ignoreErrors) promise = promise.catch(() => {});
+      if (!parallel) {
+        await promise;
+      } else {
+        allPromises.push(promise);
+      }
+    }
+  }
+
+  // If parallel logs are enabled, we have to manually exit
+  if (parallel && parallelLogs) {
+    await Promise.all(allPromises);
+    process.exit(0);
+  }
+};
+
+export default run;

--- a/src/runScript.js
+++ b/src/runScript.js
@@ -11,7 +11,7 @@ type Options = {
   ignoreSrc?: string,
   parallel?: boolean,
   parallelLogs?: boolean,
-  ignoreErrors?: boolean
+  ignoreErrors?: boolean,
 };
 
 const run = async (
@@ -29,7 +29,10 @@ const run = async (
     const pkgName = pkgNames[i];
     const { pkgPath, specs: prevSpecs } = allSpecs[pkgName];
     if (prevSpecs.scripts && prevSpecs.scripts[script]) {
-      let promise = exec(`yarn run ${script}`, { cwd: pkgPath, bareLogs: parallelLogs });
+      let promise = exec(`yarn run ${script}`, {
+        cwd: pkgPath,
+        bareLogs: parallelLogs,
+      });
       if (ignoreErrors) promise = promise.catch(() => {});
       if (!parallel) {
         await promise;

--- a/src/utils/__tests__/__snapshots__/readSpecs.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/readSpecs.test.js.snap
@@ -25,6 +25,9 @@ Object {
       "license": "MIT",
       "main": "index.js",
       "name": "oao-b",
+      "scripts": Object {
+        "start": "ls -al",
+      },
       "version": "0.1.0",
     },
   },
@@ -47,6 +50,9 @@ Object {
       "peerDependencies": Object {
         "oao-b": "*",
       },
+      "scripts": Object {
+        "start": "ls -al",
+      },
       "version": "0.1.0",
     },
   },
@@ -68,6 +74,7 @@ Object {
       "main": "index.js",
       "name": "oao-d",
       "peerDependencies": Object {},
+      "scripts": Object {},
       "version": "0.1.0",
     },
   },
@@ -121,6 +128,9 @@ Object {
       "license": "MIT",
       "main": "index.js",
       "name": "oao-b",
+      "scripts": Object {
+        "start": "ls -al",
+      },
       "version": "0.1.0",
     },
   },
@@ -143,6 +153,9 @@ Object {
       "peerDependencies": Object {
         "oao-b": "*",
       },
+      "scripts": Object {
+        "start": "ls -al",
+      },
       "version": "0.1.0",
     },
   },
@@ -164,6 +177,7 @@ Object {
       "main": "index.js",
       "name": "oao-d",
       "peerDependencies": Object {},
+      "scripts": Object {},
       "version": "0.1.0",
     },
   },
@@ -223,6 +237,7 @@ Object {
       "main": "index.js",
       "name": "oao-d",
       "peerDependencies": Object {},
+      "scripts": Object {},
       "version": "0.1.0",
     },
   },

--- a/src/utils/readSpecs.js
+++ b/src/utils/readSpecs.js
@@ -19,10 +19,13 @@ type AllSpecs = { [key: PackageName]: OaoSpecs };
 
 const readAllSpecs = async (
   src: string | Array<string>,
-  ignoreSrc?: ?string
+  ignoreSrc?: ?string,
+  includeRootPkg: boolean = true
 ): Promise<AllSpecs> => {
   const pkgPaths = await listPaths(src, ignoreSrc);
-  pkgPaths.push('.');
+  if (includeRootPkg) {
+    pkgPaths.push('.');
+  }
   const allSpecs = {};
   mainStory.info('Reading all package.json files...');
   pkgPaths.forEach(pkgPath => {
@@ -45,8 +48,7 @@ const readOneSpec = (pkgPath: string): OaoSpecs => {
   const name = pkgPath === '.' ? ROOT_PACKAGE : pkg.specs.name;
   validatePkgName(pkgPath, name);
   pkg.name = name;
-  const displayName = name === ROOT_PACKAGE ? 'MONOREPO ROOT' : name;
-  pkg.displayName = displayName;
+  pkg.displayName = name === ROOT_PACKAGE ? 'MONOREPO ROOT' : name;
   return pkg;
 };
 

--- a/test/fixtures/packages/oao-b/package.json
+++ b/test/fixtures/packages/oao-b/package.json
@@ -6,5 +6,8 @@
     "timm": "1.x",
     "oao": "*"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "scripts": {
+    "start": "ls -al"
+  }
 }

--- a/test/fixtures/packages/oao-c/package.json
+++ b/test/fixtures/packages/oao-c/package.json
@@ -13,5 +13,8 @@
     "xxl": "1.x",
     "oao-b": "*"
   },
-  "license": "MIT"
+  "license": "MIT",
+  "scripts": {
+    "start": "ls -al"
+  }
 }

--- a/test/fixtures/packages/oao-d/package.json
+++ b/test/fixtures/packages/oao-d/package.json
@@ -12,5 +12,6 @@
     "oao-c": "*"
   },
   "peerDependencies": {},
-  "license": "MIT"
+  "license": "MIT",
+  "scripts": {}
 }


### PR DESCRIPTION
This PR adds the `oao run-script` command, familiar to `oao all`.