### PR TITLE
fix: limit `parallelLimit` by number of cpus by default

### DIFF
--- a/src/utils/multiRun.js
+++ b/src/utils/multiRun.js
@@ -2,6 +2,7 @@
 
 /* eslint-disable no-constant-condition */
 
+import { cpus } from 'os';
 import { removeAllListeners, addListener } from 'storyboard';
 import parallelConsoleListener from 'storyboard-listener-console-parallel';
 import type { OaoSpecs } from './types';
@@ -122,7 +123,7 @@ const runInParallel = async (
   allJobs,
   { ignoreErrors, parallelLogs, parallelLimit, useTree }
 ) => {
-  const maxConcurrency = parallelLimit || Infinity;
+  const maxConcurrency = parallelLimit || Math.max(cpus().length - 1, 1);
   while (true) {
     // No pending idle jobs? We end the loop; Node will wait for them
     // to finish


### PR DESCRIPTION
On a 4 core machine, using 8 cores makes things way slower since most of the work is cpu bound (e.g. linting or running builds). Having a sane default makes it so we don't have to provide the option, and get the best of both worlds