### PR TITLE
Publish scoped packages with OTP

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Options:
 --publish-tag <tag>                                       publish with a custom tag (instead of `latest`)
 --changelog-path <path>                                   changelog path [CHANGELOG.md] (default: "CHANGELOG.md")
 --no-changelog                                            skip changelog updates
+--otp <code>                                              use 2FA to publish your package
+--access <type>                                           publish public or restricted packages
 -h, --help                                                output usage information
 ```
 

--- a/src/__tests__/publish.test.js
+++ b/src/__tests__/publish.test.js
@@ -216,6 +216,39 @@ describe('PUBLISH command', () => {
     });
   });
 
+  it('runs `npm publish --otp X` on dirty sub-packages', async () => {
+    const { exec } = require('../utils/shell');
+    await publish(merge(NOMINAL_OPTIONS, { otp: '123456' }));
+    expect(exec).toHaveBeenCalledTimes(
+      NUM_FIXTURE_SUBPACKAGES - NUM_FIXTURE_PRIVATE_SUBPACKAGES
+    );
+    exec.mock.calls.forEach(([cmd]) => {
+      expect(cmd).toEqual('npm publish --otp 123456');
+    });
+  });
+
+  it('runs `npm publish --access X` on dirty sub-packages', async () => {
+    const { exec } = require('../utils/shell');
+    await publish(merge(NOMINAL_OPTIONS, { access: 'public' }));
+    expect(exec).toHaveBeenCalledTimes(
+      NUM_FIXTURE_SUBPACKAGES - NUM_FIXTURE_PRIVATE_SUBPACKAGES
+    );
+    exec.mock.calls.forEach(([cmd]) => {
+      expect(cmd).toEqual('npm publish --access public');
+    });
+  });
+
+  it('does not run `npm publish --access X` with bogus access param', async () => {
+    const { exec } = require('../utils/shell');
+    await publish(merge(NOMINAL_OPTIONS, { access: 'bogus' }));
+    expect(exec).toHaveBeenCalledTimes(
+      NUM_FIXTURE_SUBPACKAGES - NUM_FIXTURE_PRIVATE_SUBPACKAGES
+    );
+    exec.mock.calls.forEach(([cmd]) => {
+      expect(cmd).toEqual('npm publish');
+    });
+  });
+
   it('skips `npm publish` when using --no-npm-publish', async () => {
     const { exec } = require('../utils/shell');
     await publish(merge(NOMINAL_OPTIONS, { npmPublish: false }));

--- a/src/index.js
+++ b/src/index.js
@@ -240,6 +240,8 @@ createCommand('publish', 'Publish updated sub-packages')
     DEFAULT_CHANGELOG
   )
   .option('--no-changelog', 'skip changelog updates')
+  .option('--otp <code>', 'use 2FA to publish your package')
+  .option('--access <type>', 'publish public or restricted packages')
   .action(cmd => {
     const options = processOptions(cmd.opts());
     initConsole(options);

--- a/src/publish.js
+++ b/src/publish.js
@@ -38,6 +38,8 @@ type Options = {
   newVersion?: string,
   npmPublish: boolean,
   publishTag?: string,
+  otp?: string,
+  access?: string,
   changelog: boolean,
   changelogPath: string,
   single: boolean,
@@ -63,6 +65,8 @@ const run = async ({
   changelog,
   changelogPath,
   single,
+  otp,
+  access,
   _date,
   _masterVersion,
 }: Options) => {
@@ -122,6 +126,9 @@ const run = async ({
       if (specs.private) continue; // we don't want npm to complain :)
       let cmd = 'npm publish';
       if (publishTag != null) cmd += ` --tag ${publishTag}`;
+      if (otp != null) cmd += ` --otp ${otp}`;
+      if (access === 'public' || access === 'restricted')
+        cmd += ` --access ${access}`;
       await exec(cmd, { cwd: pkgPath });
     }
   }


### PR DESCRIPTION
closes #88 

## OTP publishing
Pretty straight forward, pass the `--otp X` flag down to npm in shell

## Publish public scoped packages
This was a side effect of me testing out OTP publishing with a scoped monorepo.
npm CLI assumes scoped packages (f.e. `@oao/whatever`) are private, unless you set the flag to `--access public`.
npm documents 2 available params, public and restricted, so aside from adding the access param I'm also filtering on these 2 keywords.