### PR TITLE
chore: use reverse dependency tree in oao publish

### DIFF
--- a/src/__tests__/publish.test.js
+++ b/src/__tests__/publish.test.js
@@ -205,6 +205,25 @@ describe('PUBLISH command', () => {
     });
   });
 
+  it('runs `npm publish` following the dependency graph by default', async () => {
+    const { exec } = require('../utils/shell');
+    await publish(
+      Object.assign({}, NOMINAL_OPTIONS, {
+        src: 'test/fixtures/packages3/*',
+      })
+    );
+    expect(exec).toHaveBeenCalledTimes(
+      NUM_FIXTURE_SUBPACKAGES - NUM_FIXTURE_PRIVATE_SUBPACKAGES
+    );
+    const paths = exec.mock.calls.map(([, { cwd }]) => cwd);
+    expect(paths).toEqual([
+      'test/fixtures/packages3/oao-b',
+      'test/fixtures/packages3/oao',
+      'test/fixtures/packages3/oao-c',
+      'test/fixtures/packages3/oao-d',
+    ]);
+  });
+
   it('runs `npm publish --tag X` on dirty sub-packages', async () => {
     const { exec } = require('../utils/shell');
     await publish(merge(NOMINAL_OPTIONS, { publishTag: 'next' }));

--- a/src/publish.js
+++ b/src/publish.js
@@ -18,6 +18,7 @@ import {
 } from './utils/git';
 import { addVersionLine } from './utils/changelog';
 import { masterOrMainBranch } from './utils/helpers';
+import { calcGraphAndReturnAsAllSpecs } from './utils/calcGraph';
 
 const DEBUG_SKIP_CHECKS = false;
 const RELEASE_INCREMENTS = ['major', 'minor', 'patch'];
@@ -70,7 +71,9 @@ const run = async ({
   _date,
   _masterVersion,
 }: Options) => {
-  const allSpecs = await readAllSpecs(src, ignoreSrc);
+  const allSpecs = calcGraphAndReturnAsAllSpecs(
+    await readAllSpecs(src, ignoreSrc)
+  );
 
   // Confirm that we have run build and run prepublish checks
   if (confirm && !(await confirmBuild())) return;

--- a/src/utils/__tests__/__snapshots__/calcGraph.test.js.snap
+++ b/src/utils/__tests__/__snapshots__/calcGraph.test.js.snap
@@ -1,0 +1,38 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`buildGraph returns list as an allSpecs object 1`] = `
+Object {
+  "a": Object {
+    "name": "a",
+    "specs": Object {
+      "dependencies": Object {
+        "b": "*",
+        "c": "*",
+      },
+    },
+  },
+  "b": Object {
+    "name": "b",
+    "specs": Object {
+      "dependencies": Object {
+        "ext": "*",
+      },
+    },
+  },
+  "c": Object {
+    "name": "c",
+    "specs": Object {
+      "dependencies": Object {
+        "ext": "*",
+      },
+      "devDependencies": Object {
+        "d": "*",
+      },
+    },
+  },
+  "d": Object {
+    "name": "d",
+    "specs": Object {},
+  },
+}
+`;

--- a/src/utils/__tests__/calcGraph.test.js
+++ b/src/utils/__tests__/calcGraph.test.js
@@ -1,6 +1,6 @@
 /* eslint-env jest */
 
-import calcGraph from '../calcGraph';
+import calcGraph, { calcGraphAndReturnAsAllSpecs } from '../calcGraph';
 
 const ALL_SPECS_NO_CYCLE = {
   a: {
@@ -80,5 +80,10 @@ describe('buildGraph', () => {
   it('handles cycles correctly', () => {
     const dag = calcGraph(ALL_SPECS_CYCLE);
     expect(dag).toEqual(['b', 'd', 'e', 'c', 'a']);
+  });
+
+  it('returns list as an allSpecs object', () => {
+    const allSpecs = calcGraphAndReturnAsAllSpecs(ALL_SPECS_NO_CYCLE);
+    expect(allSpecs).toMatchSnapshot();
   });
 });

--- a/src/utils/calcGraph.js
+++ b/src/utils/calcGraph.js
@@ -23,6 +23,15 @@ const calcGraph = (allSpecs: AllSpecs): Array<string> => {
   return out.slice(0, out.length - 1);
 };
 
+export const calcGraphAndReturnAsAllSpecs = (allSpecs: AllSpecs): AllSpecs => {
+  const newAllSpecs = {};
+  const orderedPackages = calcGraph(allSpecs);
+  orderedPackages.forEach(pkg => {
+    newAllSpecs[pkg] = allSpecs[pkg];
+  });
+  return newAllSpecs;
+};
+
 const buildGraph = (
   allSpecs: AllSpecs,
   pkg: OaoSpecs,


### PR DESCRIPTION
closes #101 

This would allow users to run `oao publish --tree` so the leaves of a dependency tree get published first

- [x] add tests