### PR TITLE
Automatically update dependent packages when publishing

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -242,6 +242,7 @@ createCommand('publish', 'Publish updated sub-packages')
   .option('--no-changelog', 'skip changelog updates')
   .option('--otp <code>', 'use 2FA to publish your package')
   .option('--access <type>', 'publish public or restricted packages')
+  .option('--bump-dependent-reqs <range|exact|no>', 'bump dependencies ')
   .action(cmd => {
     const options = processOptions(cmd.opts());
     initConsole(options);

--- a/src/publish.js
+++ b/src/publish.js
@@ -103,23 +103,23 @@ const run = async ({
       (await promptNextVersion(masterVersion));
 
     // Confirm before proceeding
-    if (confirm && !(await confirmPublish({ dirty: toUpdate, nextVersion }))) return;
+    if (confirm && !(await confirmPublish({ toUpdate, nextVersion }))) return;
 
     const nextVersionForReqs = getDependencyReqVersion(bumpDependentReqs, nextVersion)
 
-    // Update package.json's for dirty packages AND THE ROOT PACKAGE + changelog
-    const dirtyPlusRoot = single ? toUpdate : toUpdate.concat(ROOT_PACKAGE);
-    for (let i = 0; i < dirtyPlusRoot.length; i++) {
-      const pkgName = dirtyPlusRoot[i];
+    // Update package.json's for packages to update AND THE ROOT PACKAGE + changelog
+    const toUpdatePlusRoot = single ? toUpdate : toUpdate.concat(ROOT_PACKAGE);
+    for (let i = 0; i < toUpdatePlusRoot.length; i++) {
+      const pkgName = toUpdatePlusRoot[i];
       const { specPath, specs } = allSpecs[pkgName];
       specs.version = nextVersion;
 
       // Also update dependencies to package we'll publish    
       if (nextVersionForReqs) {
-        toUpdate.forEach(dirtyPkgName => {
+        toUpdate.forEach(pkgNameToUpdate => {
           DEP_TYPES.forEach(type => {
-            if (specs[type] != null && specs[type][dirtyPkgName] != null) {
-              specs[type][dirtyPkgName] = nextVersionForReqs;
+            if (specs[type] != null && specs[type][pkgNameToUpdate] != null) {
+              specs[type][pkgNameToUpdate] = nextVersionForReqs;
             }
           });
         });
@@ -227,13 +227,13 @@ const confirmBuild = async () => {
   return out;
 };
 
-const confirmPublish = async ({ dirty, nextVersion }) => {
+const confirmPublish = async ({ toUpdate, nextVersion }) => {
   const { confirmPublish: out } = await inquirer.prompt([
     {
       name: 'confirmPublish',
       type: 'confirm',
       message:
-        `Confirm release (${chalk.yellow.bold(dirty.length)} package/s, ` +
+        `Confirm release (${chalk.yellow.bold(toUpdate.length)} package/s, ` +
         `v${chalk.cyan.bold(nextVersion)})?`,
       default: false,
     },


### PR DESCRIPTION
Hi @guigrpa,

This PR addresses the issues mentioned in #100 opened by @jeroenptrs 

What it does : 
- When a package is dirty, all packages that depend on it (recursively) get flagged as dirty as well
- Once a version is chosen, it will update the version in all packages including the dependencies.

What this PR could do better:
This current implementation is a naive approach to open the discussion, it could be improved by
- Only updating the version if it's not in range
- Allow to specify to set dependencies in ranges (^) instead of exact versions

What do you think ?